### PR TITLE
Add NF specific intialisation Heun

### DIFF
--- a/src/timesteppers/heun.jl
+++ b/src/timesteppers/heun.jl
@@ -11,6 +11,8 @@ Simple forward 2nd order Heun / improved Euler time stepping scheme.
     stage::Stage = nothing
 end
 
+Heun(::Type{NF}; kwargs...) where {NF} = Heun{NF, Nothing}(; kwargs...)
+
 default_dt(heun::Heun) = heun.Δt
 
 is_adaptive(heun::Heun) = false


### PR DESCRIPTION
For `ForwardEuler`, initialisation with the `NF` is possible, e.g. `ForwardEuler(Float32)` as mentioned in [the docs](https://numericalearth.github.io/Terrarium.jl/v0/running/time_stepping/#Overview).

For `Heun` however, `Heun(NF)` fails because a method is missing. This PR adds the method needed to allow `Heun(NF)`. 