### PR TITLE
Update compat to include Julia 1.12 in non-enzyme CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
         version:
           - '1.10'
           - '1.11'
+          - '1.12'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/examples_CI.yml
+++ b/.github/workflows/examples_CI.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         version:
           - '1.10' 
+          - '1.11'
+          - '1.12'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Julia 1.10 up until 1.12 added to CI that is not related with Enzyme.jl. 

Follow up from discussion in https://github.com/NumericalEarth/Terrarium.jl/pull/102 