### PR TITLE
Fixing use of vapor pressure deficit

### DIFF
--- a/docs/src/processes/atmosphere/atmosphere.md
+++ b/docs/src/processes/atmosphere/atmosphere.md
@@ -44,20 +44,28 @@ subtypes(Terrarium.AbstractAtmosphere)
 
 ### Vapor pressure deficit
 
-The vapor pressure deficit (VPD) quantifies how far the atmosphere is from
-saturation. It is used to drive evapotranspiration and is computed from the
-air temperature, specific humidity, and atmospheric pressure:
+The vapor pressure deficit ($\text{VPD}$) quantifies how far the atmosphere is from saturation. It is computed from the air temperature, specific humidity, and atmospheric pressure of a specific air parcel. At the atmospheric reference height at which the `PrescribedAtmosphere` is defined, the VPD is computed as:
 
 ```math
 \begin{equation}
-\Delta e = e_{\text{sat}}(T_s) - e_a(q_a, p)
+VPD = e_{\text{sat}}(T_a) - e_a(q_a, p)
 \end{equation}
 ```
 
-where $e_{\text{sat}}(T_s)$ is the saturation vapor pressure at surface temperature $T_s$,
-and $e_a = q_a p / \varepsilon$ is the actual vapor pressure, with $\varepsilon \approx 0.622$
-the ratio of molecular weights of water vapor to dry air. The corresponding specific humidity
-deficit is
+where $e_{\text{sat}}(T_a)$ is the saturation vapor pressure at surface temperature $T_a$, and $e_a = q_a p / \varepsilon$ is the actual vapor pressure, with $\varepsilon \approx 0.622$ the ratio of molecular weights of water vapor to dry air. 
+
+
+### Vapor pressure difference 
+
+The vapor pressure difference $\Delta e$ is the difference in vapor pressure between two air parcels at different heights, typically between the atmospheric reference height and the land surface. Under the typical assumption that the land surface is saturated (see e.g. [zhouPhysicalBasisEp2024](@cite)), the vapor pressure difference is computed as:
+
+```math
+\begin{equation}
+\Delta e = e_s - e_a = e_{\text{sat}}(T_s) - e_a(q_a, p)
+\end{equation}
+```
+
+with $T_s$ the land surface temperature. The corresponding specific humidity difference is
 
 ```math
 \begin{equation}
@@ -183,4 +191,11 @@ compute_vpd(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants)
 
 ```@docs; canonical = false
 compute_humidity_vpd(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants)
+```
+
+## References
+
+```@bibliography
+Pages = ["atmosphere.md"]
+Canonical = false
 ```

--- a/docs/src/processes/atmosphere/atmosphere.md
+++ b/docs/src/processes/atmosphere/atmosphere.md
@@ -54,6 +54,10 @@ VPD = e_{\text{sat}}(T_a) - e_a(q_a, p)
 
 where $e_{\text{sat}}(T_a)$ is the saturation vapor pressure at surface temperature $T_a$, and $e_a = q_a p / \varepsilon$ is the actual vapor pressure, with $\varepsilon \approx 0.622$ the ratio of molecular weights of water vapor to dry air. 
 
+```@docs; canonical = false
+vapor_pressure_deficit
+```
+
 
 ### Vapor pressure difference 
 

--- a/docs/src/processes/atmosphere/atmosphere.md
+++ b/docs/src/processes/atmosphere/atmosphere.md
@@ -59,24 +59,6 @@ vapor_pressure_deficit
 ```
 
 
-### Vapor pressure difference 
-
-The vapor pressure difference $\Delta e$ is the difference in vapor pressure between two air parcels at different heights, typically between the atmospheric reference height and the land surface. Under the typical assumption that the land surface is saturated (see e.g. [zhouPhysicalBasisEp2024](@cite)), the vapor pressure difference is computed as:
-
-```math
-\begin{equation}
-\Delta e = e_s - e_a = e_{\text{sat}}(T_s) - e_a(q_a, p)
-\end{equation}
-```
-
-with $T_s$ the land surface temperature. The corresponding specific humidity difference is
-
-```math
-\begin{equation}
-\Delta q = \frac{\varepsilon \Delta e}{p}.
-\end{equation}
-```
-
 ### Aerodynamic resistance
 
 The `PrescribedAtmosphere` delegates to an [`AbstractAerodynamics`](@ref) parameterization
@@ -191,19 +173,4 @@ aerodynamic_resistance
 
 ```@docs; canonical = false
 compute_vapor_pressure_deficit(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants)
-```
-
-```@docs; canonical = false
-compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
-```
-
-```@docs; canonical = false
-compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
-```
-
-## References
-
-```@bibliography
-Pages = ["atmosphere.md"]
-Canonical = false
 ```

--- a/docs/src/processes/atmosphere/atmosphere.md
+++ b/docs/src/processes/atmosphere/atmosphere.md
@@ -186,11 +186,15 @@ aerodynamic_resistance
 ```
 
 ```@docs; canonical = false
-compute_vpd(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants)
+compute_vapor_pressure_deficit(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants)
 ```
 
 ```@docs; canonical = false
-compute_humidity_vpd(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants)
+compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
+```
+
+```@docs; canonical = false
+compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
 ```
 
 ## References

--- a/docs/src/processes/surface_energy/turbulent_fluxes.md
+++ b/docs/src/processes/surface_energy/turbulent_fluxes.md
@@ -50,7 +50,7 @@ H_l = L \rho_a \frac{\Delta q}{r_a}
 \end{equation}
 ```
 
-where $L$ is the latent heat of vaporization or sublimation (J/kg) and $\Delta q = q_{\text{sat}}(T_s) - q_a$ is the specific humidity gradient (kg/kg) derived from the vapor pressure deficit. $H_l$ is **always non-negative** (≥ 0) and represents energy lost due to evaporation, transpiration, or sublimation. Currently, condensation (dew formation) is neglected so $\Delta q \geq 0$ and negative latent heat fluxes cannot occur.
+where $L$ is the latent heat of vaporization or sublimation (J/kg) and $\Delta q = q_{\text{sat}}(T_s) - q_a$ is the specific humidity difference (kg/kg) between surface and atmosphere. $H_l$ is **always non-negative** (≥ 0) and represents energy lost due to evaporation, transpiration, or sublimation. Currently, condensation (dew formation) is neglected so $\Delta q \geq 0$ and negative latent heat fluxes cannot occur.
 
 The latent heat flux is directly tied to:
 - **Vegetation**: Transpiration through stomata (see [Photosynthesis](@ref))

--- a/docs/src/processes/surface_energy/turbulent_fluxes.md
+++ b/docs/src/processes/surface_energy/turbulent_fluxes.md
@@ -42,7 +42,23 @@ where $c_a$ is the specific heat capacity of air (J/kg/K), $\rho_a$ is the air d
 
 ### Latent heat flux
 
-Evaporation and sublimation remove heat from the surface through the latent heat pathway:
+Evaporation and sublimation remove heat from the surface through the latent heat pathway. It is driven by the specific humidity difference $\Delta q$ (kg/kg), equivalent with the vapor pressure difference $\Delta e$ (Pa), between the surface and atmosphere.  Under the typical assumption that the land surface is saturated (see e.g. [zhouPhysicalBasisEp2024](@cite)), the vapor pressure difference is computed as:
+
+```math
+\begin{equation}
+\Delta e = e_s - e_a = e_{\text{sat}}(T_s) - e_a(q_a, p)
+\end{equation}
+```
+
+with $T_s$ the skin temperature. The corresponding specific humidity difference is
+
+```math
+\begin{equation}
+\Delta q = \frac{\varepsilon \Delta e}{p}.
+\end{equation}
+```
+
+The latent heat flux is then computed as:
 
 ```math
 \begin{equation}
@@ -50,7 +66,7 @@ H_l = L \rho_a \frac{\Delta q}{r_a}
 \end{equation}
 ```
 
-where $L$ is the latent heat of vaporization or sublimation (J/kg) and $\Delta q = q_{\text{sat}}(T_s) - q_a$ is the specific humidity difference (kg/kg) between surface and atmosphere. $H_l$ is **always non-negative** (≥ 0) and represents energy lost due to evaporation, transpiration, or sublimation. Currently, condensation (dew formation) is neglected so $\Delta q \geq 0$ and negative latent heat fluxes cannot occur.
+where $L$ is the latent heat of vaporization or sublimation (J/kg). $H_l$ is **always non-negative** (≥ 0) and represents energy lost due to evaporation, transpiration, or sublimation. Currently, condensation (dew formation) is neglected so $\Delta q \geq 0$ and negative latent heat fluxes cannot occur.
 
 The latent heat flux is directly tied to:
 - **Vegetation**: Transpiration through stomata (see [Photosynthesis](@ref))
@@ -83,4 +99,19 @@ compute_sensible_heat_flux
 
 ```@docs; canonical = false
 compute_latent_heat_flux
+```
+
+```@docs; canonical = false
+compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
+```
+
+```@docs; canonical = false
+compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
+```
+
+## References
+
+```@bibliography
+Pages = ["turbulent_fluxes.md"]
+Canonical = false
 ```

--- a/docs/src/processes/utils/physical_constants.md
+++ b/docs/src/processes/utils/physical_constants.md
@@ -53,7 +53,3 @@ stefan_boltzmann
 ```@docs; canonical = false
 psychrometric_constant
 ```
-
-```@docs; canonical = false
-compute_vpd(c::PhysicalConstants, pres, q_air, T)
-```

--- a/docs/src/processes/utils/physics_utils.md
+++ b/docs/src/processes/utils/physics_utils.md
@@ -77,6 +77,10 @@ saturation_vapor_pressure
 ```
 
 ```@docs; canonical = false
+vapor_pressure_deficit
+```
+
+```@docs; canonical = false
 vapor_pressure_to_specific_humidity
 ```
 

--- a/docs/src/processes/utils/physics_utils.md
+++ b/docs/src/processes/utils/physics_utils.md
@@ -92,7 +92,7 @@ partial_pressure_O2
 partial_pressure_CO2
 ```
 
-## [References]
+## References
 
 ```@bibliography
 Pages = ["physics_utils.md"]

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -442,3 +442,16 @@ year = {1980}
   keywords = {Groundwater,Land surface models,Numerical models,Soil moisture}
 }
 
+@article{zhouPhysicalBasisEp2024,
+  title = {Physical basis of the potential evapotranspiration and its estimation over land},
+  journal = {Journal of Hydrology},
+  volume = {641},
+  pages = {131825},
+  year = {2024},
+  issn = {0022-1694},
+  doi = {https://doi.org/10.1016/j.jhydrol.2024.131825},
+  url = {https://www.sciencedirect.com/science/article/pii/S0022169424012216},
+  author = {Sha Zhou and Bofu Yu},
+  keywords = {Energy balance approach, Aerodynamic approach, Penman equation, Potential evapotranspiration overestimation},
+}
+

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -449,8 +449,7 @@ year = {1980}
   pages = {131825},
   year = {2024},
   issn = {0022-1694},
-  doi = {https://doi.org/10.1016/j.jhydrol.2024.131825},
-  url = {https://www.sciencedirect.com/science/article/pii/S0022169424012216},
+  doi = {10.1016/j.jhydrol.2024.131825},
   author = {Sha Zhou and Bofu Yu},
   keywords = {Energy balance approach, Aerodynamic approach, Penman equation, Potential evapotranspiration overestimation},
 }

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -180,7 +180,7 @@ Retrieve or compute the specific_humidity at the current time step.
 
 Computes the vapor pressure deficit (VPD) at atmospheric reference level given the current atmospheric fields
 """
-@propagate_inbounds function compute_vapor_pressure_deficit(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
+@propagate_inbounds function compute_vapor_pressure_deficit(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants)
     T_air = air_temperature(i, j, grid, fields, atmos)
     q_air = specific_humidity(i, j, grid, fields, atmos)
     p = air_pressure(i, j, grid, fields, atmos)

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -187,32 +187,6 @@ Computes the vapor pressure deficit (VPD) at atmospheric reference level given t
     vpd = vapor_pressure_deficit(c, p, q_air, T_air)
     return vpd
 end
-"""
-    $TYPEDSIGNATURES
-
-Computes the specific humidity difference between the surface at temperature `Ts` and the current atmospheric fields.
-"""
-@propagate_inbounds function compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
-    let Δe = compute_vapor_pressure_difference(i, j, grid, fields, atmos, c, Ts),
-            p = air_pressure(i, j, grid, fields, atmos)
-        Δq = vapor_pressure_to_specific_humidity(Δe, p, c.ε)
-        return Δq
-    end
-end
-
-"""
-    $TYPEDSIGNATURES
-
-Computes the vapor pressure difference between a surface at temperature `Ts` and the current atmospheric fields.
-"""
-@propagate_inbounds function compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
-    Tair = air_temperature(i, j, grid, fields, atmos)
-    q_air = specific_humidity(i, j, grid, fields, atmos)
-    pres = air_pressure(i, j, grid, fields, atmos)
-    e_air = specific_humidity_to_vapor_pressure(q_air, pres, c.ε)
-    e_sat_s = saturation_vapor_pressure(Ts)
-    return e_sat_s
-end
 
 """
     $TYPEDEF

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -164,7 +164,7 @@ Computes the vapor pressure deficit (VPD) at atmospheric reference level given t
     T_air = air_temperature(i, j, grid, fields, atmos)
     q_air = specific_humidity(i, j, grid, fields, atmos)
     p = air_pressure(i, j, grid, fields, atmos)
-    vpd = compute_vapor_pressure_deficit(c, p, q_air, T_air)
+    vpd = vapor_pressure_deficit(c, p, q_air, T_air)
     return vpd
 end
 """

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -103,6 +103,26 @@ variables(atmos::PrescribedAtmosphere{NF}) where {NF} = (
 @inline compute_tendencies!(state, grid, atmos::PrescribedAtmosphere) = nothing
 
 """
+    $SIGNATURES
+
+Computes the vapor pressure deficit for an air parcel at temperature `T` with surface pressure `pres`
+and specific humidity of air `q_air`. Assumes that air parcel is over water when `T > 0°C` and over 
+ice when `T < 0°C`.
+"""
+@inline function vapor_pressure_deficit(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
+    # Compute saturation vapor pressure of air parcel at temperature T
+    e_sat = saturation_vapor_pressure(T)
+
+    # Convert air specific humidity to vapor pressure [Pa]
+    e_air = specific_humidity_to_vapor_pressure(q_air, pres, c.ε)
+
+    # Compute vapor pressure deficit [Pa]
+    vpd = max(e_sat - e_air, NF(0.1))
+
+    return vpd
+end
+
+"""
     aerodynamic_resistance(i, j, grid, fields, atmos::PrescribedAtmosphere)
 
 Compute the aerodynamic resistance (inverse conductance) at grid cell `i, j`.

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -172,7 +172,7 @@ end
 
 Computes the specific humidity difference between the surface at temperature `Ts` and the current atmospheric fields.
 """
-@propagate_inbounds function compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
+@propagate_inbounds function compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
     let Δe = compute_vapor_pressure_difference(i, j, grid, fields, atmos, c, Ts),
             p = air_pressure(i, j, grid, fields, atmos)
         Δq = vapor_pressure_to_specific_humidity(Δe, p, c.ε)
@@ -185,13 +185,13 @@ end
 
 Computes the vapor pressure difference between a surface at temperature `Ts` and the current atmospheric fields.
 """
-@propagate_inbounds function compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
+@propagate_inbounds function compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
     Tair = air_temperature(i, j, grid, fields, atmos)
     q_air = specific_humidity(i, j, grid, fields, atmos)
     pres = air_pressure(i, j, grid, fields, atmos)
-    Ts = isnothing(Ts) ? Tair : Ts
-    es = saturation_vapor_pressure(Ts)
-    return compute_vapor_pressure_deficit(c, pres, q_air, Ts)
+    e_air = specific_humidity_to_vapor_pressure(q_air, pres, c.ε)
+    e_sat_s = saturation_vapor_pressure(Ts)
+    return e_sat_s
 end
 
 """

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -160,7 +160,7 @@ Retrieve or compute the specific_humidity at the current time step.
 
 Computes the vapor pressure deficit (VPD) at atmospheric reference level given the current atmospheric fields
 """
-@propagate_inbounds function compute_vapor_pressure_deficit(i, j, grid, fields, atmos::PrescribedAtmosphere, c::PhysicalConstants, Ts = nothing)
+@propagate_inbounds function compute_vapor_pressure_deficit(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
     T_air = air_temperature(i, j, grid, fields, atmos)
     q_air = specific_humidity(i, j, grid, fields, atmos)
     p = air_pressure(i, j, grid, fields, atmos)

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -156,6 +156,18 @@ Retrieve or compute the specific_humidity at the current time step.
 @propagate_inbounds specific_humidity(i, j, grid, fields, ::AbstractAtmosphere{NF, PR, IR, <:SpecificHumidity}) where {NF, PR, IR} = fields.specific_humidity[i, j]
 
 """
+    $TYPESIGNATURES
+
+Computes the vapor pressure deficit (VPD) at atmospheric reference level given the current atmospheric fields
+"""
+@propagate_inbounds function compute_vapor_pressure_deficit(i, j, grid, fields, atmos::PrescribedAtmosphere, c::PhysicalConstants, Ts = nothing)
+    T_air = air_temperature(i, j, grid, fields, atmos)
+    q_air = specific_humidity(i, j, grid, fields, atmos)
+    p = air_pressure(i, j, grid, fields, atmos)
+    vpd = compute_vapor_pressure_deficit(c, p, q_air, T_air)
+    return vpd
+end
+"""
     $TYPEDSIGNATURES
 
 Computes the specific humidity difference between the surface at temperature `Ts` and the current atmospheric fields.

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -158,10 +158,10 @@ Retrieve or compute the specific_humidity at the current time step.
 """
     $TYPEDSIGNATURES
 
-Computes the specific humidity (vapor pressure) deficit over a surface at temperature `Ts` from the current atmospheric fields.
+Computes the specific humidity difference between the surface at temperature `Ts` and the current atmospheric fields.
 """
-@propagate_inbounds function compute_humidity_vpd(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
-    let Δe = compute_vpd(i, j, grid, fields, atmos, c, Ts),
+@propagate_inbounds function compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
+    let Δe = compute_vapor_pressure_difference(i, j, grid, fields, atmos, c, Ts),
             p = air_pressure(i, j, grid, fields, atmos)
         Δq = vapor_pressure_to_specific_humidity(Δe, p, c.ε)
         return Δq
@@ -171,14 +171,15 @@ end
 """
     $TYPEDSIGNATURES
 
-Computes the vapor pressure deficit over a surface at temperature `Ts` from the current atmospheric fields.
+Computes the vapor pressure difference between a surface at temperature `Ts` and the current atmospheric fields.
 """
-@propagate_inbounds function compute_vpd(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
+@propagate_inbounds function compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts = nothing)
     Tair = air_temperature(i, j, grid, fields, atmos)
     q_air = specific_humidity(i, j, grid, fields, atmos)
     pres = air_pressure(i, j, grid, fields, atmos)
     Ts = isnothing(Ts) ? Tair : Ts
-    return compute_vpd(c, pres, q_air, Ts)
+    es = saturation_vapor_pressure(Ts)
+    return compute_vapor_pressure_deficit(c, pres, q_air, Ts)
 end
 
 """

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -156,7 +156,7 @@ Retrieve or compute the specific_humidity at the current time step.
 @propagate_inbounds specific_humidity(i, j, grid, fields, ::AbstractAtmosphere{NF, PR, IR, <:SpecificHumidity}) where {NF, PR, IR} = fields.specific_humidity[i, j]
 
 """
-    $TYPESIGNATURES
+    $TYPEDSIGNATURES
 
 Computes the vapor pressure deficit (VPD) at atmospheric reference level given the current atmospheric fields
 """

--- a/src/processes/physical_constants.jl
+++ b/src/processes/physical_constants.jl
@@ -73,23 +73,3 @@ and ϵ is the emissivity.
 Calcualte the psychrometric constant at the given atmospheric pressure `p`.
 """
 @inline psychrometric_constant(c::PhysicalConstants, p) = c.cₐ * p / (c.Llg * c.ε)
-
-"""
-    $SIGNATURES
-
-Computes the vapor pressure deficit for an air parcel at temperature `T` with surface pressure `pres`
-and specific humidity of air `q_air`. Assumes that air parcel is over water when `T > 0°C` and over 
-ice when `T < 0°C`.
-"""
-@inline function compute_vapor_pressure_deficit(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
-    # Compute saturation vapor pressure over a surface at temperature Ts
-    e_sat = saturation_vapor_pressure(T)
-
-    # Convert air specific humidity to vapor pressure [Pa]
-    e_air = q_air * pres / (c.ε + (1 - c.ε) * q_air)
-
-    # Compute vapor pressure deficit [Pa]
-    vpd = max(e_sat - e_air, NF(0.1))
-
-    return vpd
-end

--- a/src/processes/physical_constants.jl
+++ b/src/processes/physical_constants.jl
@@ -77,13 +77,11 @@ Calcualte the psychrometric constant at the given atmospheric pressure `p`.
 """
     $SIGNATURES
 
-Computes the vapor pressure deficit over a surface at temperature `T` from the given
-surface pressure `pres` and specific humidity of air `q_air`.
+Computes the vapor pressure deficit for an air parcel at temperature `T` with surface pressure `pres`
+and specific humidity of air `q_air`. Assumes that air parcel is over water when `T > 0°C` and over 
+ice when `T < 0°C`.
 """
-@inline function compute_vpd(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
-    # Saturation vapor pressure over water [Pa]
-    # e_sat_w = NF(6.1094e2) * exp(NF(17.625) * T_air / (NF(243.04) + T_air))
-
+@inline function compute_vapor_pressure_deficit(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
     # Compute saturation vapor pressure over a surface at temperature Ts
     e_sat = saturation_vapor_pressure(T)
 

--- a/src/processes/physics_utils.jl
+++ b/src/processes/physics_utils.jl
@@ -38,11 +38,11 @@ molecular weight ratio ε.
 @inline vapor_pressure_to_specific_humidity(e, p, ε) = ε * e / p
 
 """
-    relative_to_specific_humidity(r_h, pr, Tair)
+    relative_to_specific_humidity(r_h, pr, T, ε)
 
-Derives specific humidity from measured relative humidity, air pressure, and air temperature.
+Derives specific humidity from measured relative humidity, air pressure, air temperature, and molecular weight ratio.
 """
-@inline relative_to_specific_humidity(r_h, pr, T) = 0.622 * (r_h / 100) * saturation_vapor_pressure(Tair) / pr
+@inline relative_to_specific_humidity(r_h, pr, T, ε) = ε * (r_h / 100) * saturation_vapor_pressure(T) / pr
 
 # saturation vapor pressure
 """

--- a/src/processes/physics_utils.jl
+++ b/src/processes/physics_utils.jl
@@ -89,7 +89,7 @@ Computes the vapor pressure deficit for an air parcel at temperature `T` with su
 and specific humidity of air `q_air`. Assumes that air parcel is over water when `T > 0°C` and over 
 ice when `T < 0°C`.
 """
-@inline function compute_vapor_pressure_deficit(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
+@inline function vapor_pressure_deficit(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
     # Compute saturation vapor pressure of air parcel at temperature T
     e_sat = saturation_vapor_pressure(T)
 

--- a/src/processes/physics_utils.jl
+++ b/src/processes/physics_utils.jl
@@ -38,6 +38,17 @@ molecular weight ratio ε.
 @inline vapor_pressure_to_specific_humidity(e, p, ε) = ε * e / p
 
 """
+    specific_humidity_to_vapor_pressure(q, p, ε)
+
+Convert the specific humidity `q` to vapor pressure at the given pressure `p` based on the
+molecular weight ratio ε.
+"""
+@inline function specific_humidity_to_vapor_pressure(q, p, ε)
+    e = q * p / (ε + (1 - ε) * q)
+    return e
+end
+
+"""
     relative_to_specific_humidity(r_h, pr, T, ε)
 
 Derives specific humidity from measured relative humidity, air pressure, air temperature, and molecular weight ratio.

--- a/src/processes/physics_utils.jl
+++ b/src/processes/physics_utils.jl
@@ -81,3 +81,23 @@ Coefficients of August-Roche-Magnus equation taken from [alduchovImprovedMagnusF
         saturation_vapor_pressure(T, NF(611.0), NF(17.62), NF(243.12))
     end
 end
+
+"""
+    $SIGNATURES
+
+Computes the vapor pressure deficit for an air parcel at temperature `T` with surface pressure `pres`
+and specific humidity of air `q_air`. Assumes that air parcel is over water when `T > 0°C` and over 
+ice when `T < 0°C`.
+"""
+@inline function compute_vapor_pressure_deficit(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
+    # Compute saturation vapor pressure of air parcel at temperature T
+    e_sat = saturation_vapor_pressure(T)
+
+    # Convert air specific humidity to vapor pressure [Pa]
+    e_air = specific_humidity_to_vapor_pressure(q_air, pres, c.ε)
+
+    # Compute vapor pressure deficit [Pa]
+    vpd = max(e_sat - e_air, NF(0.1))
+
+    return vpd
+end

--- a/src/processes/physics_utils.jl
+++ b/src/processes/physics_utils.jl
@@ -81,23 +81,3 @@ Coefficients of August-Roche-Magnus equation taken from [alduchovImprovedMagnusF
         saturation_vapor_pressure(T, NF(611.0), NF(17.62), NF(243.12))
     end
 end
-
-"""
-    $SIGNATURES
-
-Computes the vapor pressure deficit for an air parcel at temperature `T` with surface pressure `pres`
-and specific humidity of air `q_air`. Assumes that air parcel is over water when `T > 0°C` and over 
-ice when `T < 0°C`.
-"""
-@inline function vapor_pressure_deficit(c::PhysicalConstants{NF}, pres, q_air, T) where {NF}
-    # Compute saturation vapor pressure of air parcel at temperature T
-    e_sat = saturation_vapor_pressure(T)
-
-    # Convert air specific humidity to vapor pressure [Pa]
-    e_air = specific_humidity_to_vapor_pressure(q_air, pres, c.ε)
-
-    # Compute vapor pressure deficit [Pa]
-    vpd = max(e_sat - e_air, NF(0.1))
-
-    return vpd
-end

--- a/src/processes/physics_utils.jl
+++ b/src/processes/physics_utils.jl
@@ -54,12 +54,11 @@ coefficients a₁, a₂, and a₃.
 @inline saturation_vapor_pressure(T, a₁, a₂, a₃) = a₁ * exp(a₂ * T / (T + a₃))
 
 """
-    saturation_vapor_pressure(T, Ts=T)
+    saturation_vapor_pressure(T)
 
-Saturation vapor pressure at the given temperature `T`, accounting for both frozen (`T < 0°C`)
-and unfrozen conditions.
-
-Coefficients taken from [alduchovImprovedMagnusForm1996](@cite).
+Saturation vapor pressure of an air parcel at the given temperature `T`. By default, the saturation vapor
+pressure is computed over ice for `T <= 0°C` and over water for `T > 0°C`
+Coefficients of August-Roche-Magnus equation taken from [alduchovImprovedMagnusForm1996](@cite).
 
 # References
 * [alduchovImprovedMagnusForm1996](@cite) Alduchov and Eskridge, Journal of Applied Meteorology and Climatology (1996)

--- a/src/processes/surface_energy/turbulent_fluxes.jl
+++ b/src/processes/surface_energy/turbulent_fluxes.jl
@@ -52,12 +52,12 @@ end
 """
     $TYPEDSIGNATURES
     
-Computes the difference in vapor pressure between the (saturated) surface at temperature `Ts`
+Computes the difference in vapor pressure between a saturated surface at temperature `T`
 and the atmosphere, defined by its specific humidity `q_air`.
 """
-function vapor_pressure_difference(c::PhysicalConstants, p, q_air, Ts)
+function vapor_pressure_difference(c::PhysicalConstants, p, q_air, T)
     e_air = specific_humidity_to_vapor_pressure(q_air, p, c.ε)
-    e_sat_s = saturation_vapor_pressure(Ts)
+    e_sat_s = saturation_vapor_pressure(T)
     Δe = e_sat_s - e_air
     return Δe
 end
@@ -65,11 +65,11 @@ end
 """
     $TYPEDSIGNATURES
 
-Computes the difference in specific humidity between the (saturated) surface at temperature `Ts`
+Computes the difference in specific humidity between a saturated surface at temperature `T`
 and the atmosphere, defined by its specific humidity `q_air`.
 """
-function specific_humidity_difference(c::PhysicalConstants, p, q_air, Ts)
-    e_sat_s = saturation_vapor_pressure(Ts)
+function specific_humidity_difference(c::PhysicalConstants, p, q_air, T)
+    e_sat_s = saturation_vapor_pressure(T)
     q_sat_s = vapor_pressure_to_specific_humidity(e_sat_s, p, c.ε)
     Δq = q_sat_s - q_air
     return Δq
@@ -106,24 +106,24 @@ end
 """
     $TYPEDSIGNATURES
 
-Computes the specific humidity difference between the surface at temperature `Ts` and the current atmospheric fields.
+Computes the specific humidity difference between a saturated surface at temperature `T` and the current atmospheric fields.
 """
-@propagate_inbounds function compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
+@propagate_inbounds function compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, T)
     q_air = specific_humidity(i, j, grid, fields, atmos)
     pres = air_pressure(i, j, grid, fields, atmos)
-    Δq = specific_humidity_difference(c, pres, q_air, Ts)
+    Δq = specific_humidity_difference(c, pres, q_air, T)
     return Δq
 end
 
 """
     $TYPEDSIGNATURES
 
-Computes the vapor pressure difference between a surface at temperature `Ts` and the current atmospheric fields.
+Computes the vapor pressure difference between a saturated surface at temperature `T` and the current atmospheric fields.
 """
-@propagate_inbounds function compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
+@propagate_inbounds function compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, T)
     q_air = specific_humidity(i, j, grid, fields, atmos)
     pres = air_pressure(i, j, grid, fields, atmos)
-    Δe = vapor_pressure_difference(c, pres, q_air, Ts)
+    Δe = vapor_pressure_difference(c, pres, q_air, T)
     return Δe
 end
 

--- a/src/processes/surface_energy/turbulent_fluxes.jl
+++ b/src/processes/surface_energy/turbulent_fluxes.jl
@@ -119,7 +119,7 @@ to the latent heat flux.
             ρₐ = constants.ρₐ, # density of air
             Tₛ = skin_temperature(i, j, grid, fields, skinT),
             rₐ = aerodynamic_resistance(i, j, grid, fields, atmos), # aerodynamic resistance
-            Δq = compute_humidity_vpd(i, j, grid, fields, atmos, constants, Tₛ),
+            Δq = compute_specific_humidity_difference(i, j, grid, fields, atmos, constants, Tₛ),
             Q_h = Δq / rₐ  # humidity flux
         # Calculate latent heat flux (positive upwards)
         Hₗ = compute_latent_heat_flux(tur, Q_h, ρₐ, L)

--- a/src/processes/surface_energy/turbulent_fluxes.jl
+++ b/src/processes/surface_energy/turbulent_fluxes.jl
@@ -49,6 +49,32 @@ function compute_latent_heat_flux(::DiagnosedTurbulentFluxes, Q_h, ρₐ, Lsl)
     return Hₗ
 end
 
+"""
+    $TYPEDSIGNATURES
+    
+Computes the difference in vapor pressure between the (saturated) surface at temperature `Ts`
+and the atmosphere, defined by its specific humidity `q_air`.
+"""
+function vapor_pressure_difference(c::PhysicalConstants, p, q_air, Ts)
+    e_air = specific_humidity_to_vapor_pressure(q_air, p, c.ε)
+    e_sat_s = saturation_vapor_pressure(Ts)
+    Δe = e_sat_s - e_air
+    return Δe
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Computes the difference in specific humidity between the (saturated) surface at temperature `Ts`
+and the atmosphere, defined by its specific humidity `q_air`.
+"""
+function specific_humidity_difference(c::PhysicalConstants, p, q_air, Ts)
+    e_sat_s = saturation_vapor_pressure(Ts)
+    q_sat_s = vapor_pressure_to_specific_humidity(e_sat_s, p, c.ε)
+    Δq = q_sat_s - q_air
+    return Δq
+end
+
 ## Top-level interface methods
 
 variables(::DiagnosedTurbulentFluxes) = (
@@ -76,6 +102,30 @@ function compute_auxiliary!(
 end
 
 ## Kernel functions
+
+"""
+    $TYPEDSIGNATURES
+
+Computes the specific humidity difference between the surface at temperature `Ts` and the current atmospheric fields.
+"""
+@propagate_inbounds function compute_specific_humidity_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
+    q_air = specific_humidity(i, j, grid, fields, atmos)
+    pres = air_pressure(i, j, grid, fields, atmos)
+    Δq = specific_humidity_difference(c, pres, q_air, Ts)
+    return Δq
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Computes the vapor pressure difference between a surface at temperature `Ts` and the current atmospheric fields.
+"""
+@propagate_inbounds function compute_vapor_pressure_difference(i, j, grid, fields, atmos::AbstractAtmosphere, c::PhysicalConstants, Ts)
+    q_air = specific_humidity(i, j, grid, fields, atmos)
+    pres = air_pressure(i, j, grid, fields, atmos)
+    Δe = vapor_pressure_difference(c, pres, q_air, Ts)
+    return Δe
+end
 
 """
     $TYPEDSIGNATURES

--- a/src/processes/surface_hydrology/evapotranspiration/bare_ground_evaporation.jl
+++ b/src/processes/surface_hydrology/evapotranspiration/bare_ground_evaporation.jl
@@ -6,7 +6,7 @@ Evaporation scheme for bare ground that calculates the humidity flux as
 ```math
 E = \\beta \\frac{\\Delta q}{r_a}
 ```
-where `Δq` is the vapor pressure gradient in terms of specific humidity, `rₐ` is aerodynamic resistance,
+where `Δq` is the specific humidity difference, `rₐ` is aerodynamic resistance,
 and `β` is an evaporation limiting factor.
 """
 struct BareGroundEvaporation{NF, GR <: AbstractGroundEvaporationResistanceFactor} <: AbstractEvapotranspiration{NF}

--- a/src/processes/surface_hydrology/evapotranspiration/bare_ground_evaporation.jl
+++ b/src/processes/surface_hydrology/evapotranspiration/bare_ground_evaporation.jl
@@ -56,7 +56,7 @@ end
     Ts = fields.skin_temperature[i, j]
     rₐ = aerodynamic_resistance(i, j, grid, fields, atmos) # aerodynamic resistance
     β = ground_evaporation_resistance_factor(i, j, grid, fields, evaporation.ground_resistance, soil)
-    Δq = compute_humidity_vpd(i, j, grid, fields, atmos, constants, Ts)
+    Δq = compute_specific_humidity_difference(i, j, grid, fields, atmos, constants, Ts)
     # Calculate water evaporation flux in m/s (positive upwards)
     return out.evaporation_ground[i, j, 1] = β * Δq / rₐ
 end

--- a/src/processes/surface_hydrology/evapotranspiration/canopy_evapotranspiration.jl
+++ b/src/processes/surface_hydrology/evapotranspiration/canopy_evapotranspiration.jl
@@ -142,8 +142,8 @@ for the given scheme `evapotranspiration` and process dependencies.
     gw_can = fields.canopy_water_conductance[i, j] # stomatal conductance (assumed to be defined by vegetation)
 
     # Compute VPD and resistance terms
-    Δqs = compute_humidity_vpd(i, j, grid, fields, atmos, constants, Ts) # humidity gradient between canopy and atmosphere
-    Δqg = compute_humidity_vpd(i, j, grid, fields, atmos, constants, Tg) # humidity gradient between ground and canopy
+    Δqs = compute_specific_humidity_difference(i, j, grid, fields, atmos, constants, Ts) # humidity difference between canopy and atmosphere
+    Δqg = compute_specific_humidity_difference(i, j, grid, fields, atmos, constants, Tg) # humidity difference between ground and canopy
     rₐ = aerodynamic_resistance(i, j, grid, fields, atmos) # aerodynamic resistance
     rₑ = aerodynamic_resistance(i, j, grid, fields, atmos, evapotranspiration, vegetation) # aerodynamic resistance between ground and canopy
     f_can = saturation_canopy_water(i, j, grid, fields, canopy_interception)

--- a/src/processes/vegetation/stomatal_conductance.jl
+++ b/src/processes/vegetation/stomatal_conductance.jl
@@ -114,7 +114,7 @@ Returns tuple (gw_can, λc) for use in photosynthesis and transpiration calculat
     β = fields.soil_moisture_limiting_factor[i, j]
 
     # Compute vpd [Pa]
-    vpd = compute_vpd(i, j, grid, fields, atmos, constants)
+    vpd = compute_vapor_pressure_deficit(i, j, grid, fields, atmos, constants)
 
     # Compute conductance gw_can and internal CO2 ratio λc
     gw_can = compute_gw_can(stomcond, photo, vpd, An, CO2, LAI, β)


### PR DESCRIPTION
First attempt at closing https://github.com/NumericalEarth/Terrarium.jl/issues/106

2 questions before continuing @bgroenks96 :

1. Is the VPD functionality a physics util or something that is part of the atmosphere? Right now, docs are in atmosphere but the core computation in physics utils, which is a bit confusing.
2. Instead of implementing a lot of the basic functionality in physics_utils, have you considered using [Thermodynamics.jl](https://github.com/CliMA/Thermodynamics.jl)? Just as for the surface aerodynamics (https://github.com/NumericalEarth/Terrarium.jl/issues/97), maybe there is an for wanting the thermodynamics to be consistent across multiple earth system components. This package would give functionality for e.g. calculating VPD (see [here](https://clima.github.io/Thermodynamics.jl/v1.2/API/#Thermodynamics.vapor_pressure_deficit) and saturation vapor pressure (see [here](https://clima.github.io/Thermodynamics.jl/v1.2/API/#Thermodynamics.saturation_vapor_pressure)). It is already a dependency of NumericalEarth.jl (see [here](https://github.com/NumericalEarth/NumericalEarth.jl/blob/6ec0e7714525e642b22799c817a72af7718c40c1/Project.toml#L30)), although I don't know to which extent it is used in that project. If interested, I'd be happy to help wit the PR for this. 