### PR TITLE
Don't run CI on 1.11 anymore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.11'
           - '1.12'
         os:
           - ubuntu-latest

--- a/.github/workflows/examples_CI.yml
+++ b/.github/workflows/examples_CI.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         version:
           - '1.10' 
-          - '1.11'
           - '1.12'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Just a minor housekeeping thing. Oceananigans was never fully compatible with 1.11 anyway, and this saves some CI time (which isn't an issue yet, but will probably become one). 