### PR TITLE
Split timestepper and cache and revise Heun

### DIFF
--- a/src/models/coupled/land_model.jl
+++ b/src/models/coupled/land_model.jl
@@ -46,6 +46,7 @@ end
 function initialize(
         model::LandModel{NF};
         clock = Clock(time = zero(NF)),
+        timestepper = nothing,
         boundary_conditions = (;),
         fields = (;),
         input_variables = ()
@@ -62,7 +63,7 @@ function initialize(
     bcs = merge_boundary_conditions(boundary_conditions, ground_heat_flux_bc, infiltration_bc)
     # Merge user-defined fields with BC fields
     fields = merge((; ground_heat_flux, infiltration), fields)
-    return initialize(vars, grid; clock, boundary_conditions = bcs, fields)
+    return initialize(vars, grid; clock, timestepper, boundary_conditions = bcs, fields)
 end
 
 function initialize!(state, model::LandModel)

--- a/src/models/coupled/land_model.jl
+++ b/src/models/coupled/land_model.jl
@@ -46,7 +46,7 @@ end
 function initialize(
         model::LandModel{NF};
         clock = Clock(time = zero(NF)),
-        timestepper = nothing,
+        timestepper = ForwardEuler{NF}(),
         boundary_conditions = (;),
         fields = (;),
         input_variables = ()

--- a/src/state_variables.jl
+++ b/src/state_variables.jl
@@ -25,7 +25,7 @@ struct StateVariables{
     auxiliary::NamedTuple{auxnames, AuxFields}
     inputs::NamedTuple{inputnames, InputFields}
     namespaces::NamedTuple{nsnames, Namespaces}
-    cache::NamedTuple{cachenames, CacheFields}
+    timestepper_cache::NamedTuple{cachenames, CacheFields}
     clock::ClockType
 
     function StateVariables(
@@ -36,7 +36,7 @@ struct StateVariables{
             auxiliary::NamedTuple{auxnames, AuxFields},
             inputs::NamedTuple{inputnames, InputFields},
             namespaces::NamedTuple{nsnames, Namespaces},
-            cache::NamedTuple{cachenames, CacheFields},
+            timestepper_cache::NamedTuple{cachenames, CacheFields},
             clock::ClockType,
         ) where {
             NF, prognames, auxnames, inputnames, nsnames, cachenames,
@@ -51,7 +51,7 @@ struct StateVariables{
             auxiliary,
             inputs,
             namespaces,
-            cache,
+            timestepper_cache,
             clock,
         )
     end
@@ -65,7 +65,7 @@ end
 @inline namespace_names(state::StateVariables) = keys(getfield(state, :namespaces))
 @inline closure_names(::StateVariables{NF, pnames, cnames}) where {NF, pnames, cnames} = cnames
 
-@inline cache_names(state::StateVariables) = keys(getfield(state, :cache))
+@inline timestepper_cache_names(state::StateVariables) = keys(getfield(state, :timestepper_cache))
 
 # Allow reconstruction from properties
 ConstructionBase.constructorof(::Type{StateVariables{NF, pnames, cnames}}) where {NF, pnames, cnames} = (args...) -> StateVariables(NF, cnames, args...)
@@ -483,7 +483,7 @@ function Adapt.adapt_structure(to, state::StateVariables{NF}) where {NF}
         Adapt.adapt_structure(to, state.auxiliary),
         Adapt.adapt_structure(to, state.inputs),
         Adapt.adapt_structure(to, state.namespaces),
-        Adapt.adapt_structure(to, state.cache),
+        Adapt.adapt_structure(to, state.timestepper_cache),
         Adapt.adapt_structure(to, state.clock),
     )
 end
@@ -549,7 +549,7 @@ end
 
 function Base.summary(state::StateVariables{NF}) where {NF}
     clockstr = summary(state.clock)
-    str = "StateVariables{$NF}(clock = $clockstr, prognostic = $(keys(state.prognostic)), auxiliary = $(keys(state.auxiliary)), inputs = $(keys(state.inputs)), namespaces = $(keys(state.namespaces)), cache = $(cache_names(state)))"
+    str = "StateVariables{$NF}(clock = $clockstr, prognostic = $(keys(state.prognostic)), auxiliary = $(keys(state.auxiliary)), inputs = $(keys(state.inputs)), namespaces = $(keys(state.namespaces)), timestepper_cache = $(timestepper_cache_names(state)))"
     return str
 end
 
@@ -568,5 +568,5 @@ function Base.show(io::IO, state::StateVariables{NF}) where {NF}
     println(io)
     print(io, "├─ Namespaces: $(keys(state.namespaces))")
     println(io)
-    return print(io, "└─ Cache: $(cache_names(state))")
+    return print(io, "└─ Timestepper cache: $(timestepper_cache_names(state))")
 end

--- a/src/state_variables.jl
+++ b/src/state_variables.jl
@@ -15,8 +15,9 @@ by the timestepping scheme.
 """
 struct StateVariables{
         NF,
-        prognames, closurenames, auxnames, inputnames, nsnames,
+        prognames, closurenames, auxnames, inputnames, nsnames, cachenames,
         ProgFields, TendFields, AuxFields, InputFields, Namespaces,
+        CacheFields,
         ClockType,
     } <: AbstractStateVariables
     prognostic::NamedTuple{prognames, ProgFields}
@@ -24,6 +25,7 @@ struct StateVariables{
     auxiliary::NamedTuple{auxnames, AuxFields}
     inputs::NamedTuple{inputnames, InputFields}
     namespaces::NamedTuple{nsnames, Namespaces}
+    cache::NamedTuple{cachenames, CacheFields}
     clock::ClockType
 
     function StateVariables(
@@ -34,23 +36,26 @@ struct StateVariables{
             auxiliary::NamedTuple{auxnames, AuxFields},
             inputs::NamedTuple{inputnames, InputFields},
             namespaces::NamedTuple{nsnames, Namespaces},
-            clock::ClockType
+            cache::NamedTuple{cachenames, CacheFields},
+            clock::ClockType,
         ) where {
-            NF, prognames, auxnames, inputnames, nsnames,
-            ProgFields, TendFields, AuxFields, InputFields, Namespaces, ClockType,
+            NF, prognames, auxnames, inputnames, nsnames, cachenames,
+            ProgFields, TendFields, AuxFields, InputFields, Namespaces, CacheFields, ClockType,
         }
         return new{
-            NF, prognames, closurenames, auxnames, inputnames, nsnames,
-            ProgFields, TendFields, AuxFields, InputFields, Namespaces, ClockType,
+            NF, prognames, closurenames, auxnames, inputnames, nsnames, cachenames,
+            ProgFields, TendFields, AuxFields, InputFields, Namespaces, CacheFields, ClockType,
         }(
             prognostic,
             tendencies,
             auxiliary,
             inputs,
             namespaces,
-            clock
+            cache,
+            clock,
         )
     end
+
 end
 
 # Name getters (always type-stable, inlined constant propagation)
@@ -59,6 +64,8 @@ end
 @inline input_names(state::StateVariables) = keys(getfield(state, :inputs))
 @inline namespace_names(state::StateVariables) = keys(getfield(state, :namespaces))
 @inline closure_names(::StateVariables{NF, pnames, cnames}) where {NF, pnames, cnames} = cnames
+
+@inline cache_names(state::StateVariables) = keys(getfield(state, :cache))
 
 # Allow reconstruction from properties
 ConstructionBase.constructorof(::Type{StateVariables{NF, pnames, cnames}}) where {NF, pnames, cnames} = (args...) -> StateVariables(NF, cnames, args...)
@@ -304,12 +311,13 @@ function initialize(
         model::AbstractModel{NF};
         clock = Clock(time = zero(NF)),
         input_variables = (),
+        timestepper = nothing,
         boundary_conditions = (;),
         initializers = (;),
         fields = (;)
     ) where {NF}
     vars = Variables(tuplejoin(variables(model), input_variables))
-    state = initialize(vars, model.grid; clock, boundary_conditions, initializers, fields)
+    state = initialize(vars, model.grid; clock, timestepper, boundary_conditions, initializers, fields)
     return state
 end
 
@@ -325,12 +333,13 @@ function initialize(
         grid::AbstractLandGrid{NF};
         clock = Clock(time = zero(NF)),
         input_variables = (),
+        timestepper = nothing,
         boundary_conditions = (;),
         initializers = (;),
         fields = (;)
     ) where {NF}
     vars = Variables(tuplejoin(variables(process), input_variables))
-    state = initialize(vars, grid; clock, boundary_conditions, initializers, fields)
+    state = initialize(vars, grid; clock, timestepper, boundary_conditions, initializers, fields)
     return state
 end
 
@@ -347,6 +356,7 @@ function initialize(
         @nospecialize(vars::Variables),
         grid::AbstractLandGrid{NF};
         clock::Clock = Clock(time = 0.0),
+        timestepper = nothing,
         boundary_conditions = (;),
         initializers = (;),
         fields = (;)
@@ -364,7 +374,8 @@ function initialize(
     end
     # get closure variable names
     closurenames = map(varname, closure_variables(values(vars.prognostic)))
-    # construct and return StateVariables
+    # construct StateVariables with an empty cache; the timestepper-specific cache
+    # is allocated below now that all other state variables have been initialized
     state = StateVariables(
         NF,
         closurenames,
@@ -373,7 +384,20 @@ function initialize(
         auxiliary_fields,
         input_fields,
         namespaces,
-        clock
+        (;),
+        clock,
+    )
+    cache = initialize(timestepper, state)
+    state = StateVariables(
+        NF,
+        closurenames,
+        prognostic_fields,
+        tendency_fields,
+        auxiliary_fields,
+        input_fields,
+        namespaces,
+        cache,
+        clock,
     )
     # Apply Field initializers
     initialize!(state, initializers)
@@ -459,6 +483,7 @@ function Adapt.adapt_structure(to, state::StateVariables{NF}) where {NF}
         Adapt.adapt_structure(to, state.auxiliary),
         Adapt.adapt_structure(to, state.inputs),
         Adapt.adapt_structure(to, state.namespaces),
+        Adapt.adapt_structure(to, state.cache),
         Adapt.adapt_structure(to, state.clock),
     )
 end
@@ -524,7 +549,7 @@ end
 
 function Base.summary(state::StateVariables{NF}) where {NF}
     clockstr = summary(state.clock)
-    str = "StateVariables{$NF}(clock = $clockstr, prognostic = $(keys(state.prognostic)), auxiliary = $(keys(state.auxiliary)), inputs = $(keys(state.inputs)), namespaces = $(keys(state.namespaces)))"
+    str = "StateVariables{$NF}(clock = $clockstr, prognostic = $(keys(state.prognostic)), auxiliary = $(keys(state.auxiliary)), inputs = $(keys(state.inputs)), namespaces = $(keys(state.namespaces)), cache = $(cache_names(state)))"
     return str
 end
 
@@ -541,5 +566,7 @@ function Base.show(io::IO, state::StateVariables{NF}) where {NF}
     print(io, "├─ Inputs: ")
     show(io, state.inputs)
     println(io)
-    return print(io, "├─ Namespaces: $(keys(state.namespaces))")
+    print(io, "├─ Namespaces: $(keys(state.namespaces))")
+    println(io)
+    return print(io, "└─ Cache: $(cache_names(state))")
 end

--- a/src/state_variables.jl
+++ b/src/state_variables.jl
@@ -376,7 +376,7 @@ function initialize(
     closurenames = map(varname, closure_variables(values(vars.prognostic)))
     # construct StateVariables with an empty cache; the timestepper-specific cache
     # is allocated below now that all other state variables have been initialized
-    state = StateVariables(
+    initial_state = StateVariables(
         NF,
         closurenames,
         prognostic_fields,
@@ -387,7 +387,7 @@ function initialize(
         (;),
         clock,
     )
-    cache = initialize(timestepper, state)
+    cache = initialize(timestepper, initial_state)
     state = StateVariables(
         NF,
         closurenames,

--- a/src/state_variables.jl
+++ b/src/state_variables.jl
@@ -311,7 +311,7 @@ function initialize(
         model::AbstractModel{NF};
         clock = Clock(time = zero(NF)),
         input_variables = (),
-        timestepper = nothing,
+        timestepper = ForwardEuler{NF}(),
         boundary_conditions = (;),
         initializers = (;),
         fields = (;)
@@ -333,7 +333,7 @@ function initialize(
         grid::AbstractLandGrid{NF};
         clock = Clock(time = zero(NF)),
         input_variables = (),
-        timestepper = nothing,
+        timestepper = ForwardEuler{NF}(),
         boundary_conditions = (;),
         initializers = (;),
         fields = (;)
@@ -356,7 +356,7 @@ function initialize(
         @nospecialize(vars::Variables),
         grid::AbstractLandGrid{NF};
         clock::Clock = Clock(time = 0.0),
-        timestepper = nothing,
+        timestepper = ForwardEuler{NF}(),
         boundary_conditions = (;),
         initializers = (;),
         fields = (;)

--- a/src/timesteppers/abstract_timestepper.jl
+++ b/src/timesteppers/abstract_timestepper.jl
@@ -11,13 +11,6 @@ Base type for time steppers.
 abstract type AbstractTimeStepper{NF} end
 
 """
-    is_initialized(timestepper::AbstractTimeStepper)
-
-Return `true` if the timestepper is initialized, `false` otherwise.
-"""
-function is_initialized end
-
-"""
     default_dt(timestepper::AbstractTimeStepper)
 
 Get the current timestep size for the time stepper.
@@ -47,11 +40,14 @@ variables defined by `model`.
 timestep!(state, model::AbstractModel, timestepper::AbstractTimeStepper, Δt) = nothing
 
 """
-    initialize(::AbstractTimeStepper, model, state) where {NF}
+    initialize(::AbstractTimeStepper, model, state)
 
 Initialize and return the time stepping state cache for the given time stepper.
+. Allocate and return a `NamedTuple` of intermediate fields/state required by the given
+`timestepper`. Time steppers that do not require any cache can fall back to the default 
+implementation, which returns an empty `NamedTuple`.
 """
-initialize(timestepper::AbstractTimeStepper, model, state) = timestepper
+initialize(timestepper::AbstractTimeStepper, model, state) = (;)
 
 """
     $SIGNATURES
@@ -63,7 +59,6 @@ additional dispatches of `explicit_step_kernel!(field, tendency, ::AbstractLandG
 can be defined to implement more specialized time-stepping schemes.
 """
 function explicit_step!(state, grid::AbstractLandGrid, timestepper::AbstractTimeStepper, Δt)
-    @assert is_initialized(timestepper)
     fastiterate(keys(state.prognostic)) do name
         # apply flux BCs, if present
         compute_z_bcs!(state.tendencies[name], state.prognostic[name], grid, state)

--- a/src/timesteppers/abstract_timestepper.jl
+++ b/src/timesteppers/abstract_timestepper.jl
@@ -48,7 +48,6 @@ Initialize and return the time stepping state cache for the given time stepper.
 implementation, which returns an empty `NamedTuple`.
 """
 initialize(timestepper::AbstractTimeStepper, state) = (;)
-initialize(::Nothing, state) = (;)
 
 """
     $SIGNATURES

--- a/src/timesteppers/abstract_timestepper.jl
+++ b/src/timesteppers/abstract_timestepper.jl
@@ -40,14 +40,15 @@ variables defined by `model`.
 timestep!(state, model::AbstractModel, timestepper::AbstractTimeStepper, Δt) = nothing
 
 """
-    initialize(::AbstractTimeStepper, model, state)
+    initialize(::AbstractTimeStepper, state)
 
 Initialize and return the time stepping state cache for the given time stepper.
 . Allocate and return a `NamedTuple` of intermediate fields/state required by the given
 `timestepper`. Time steppers that do not require any cache can fall back to the default 
 implementation, which returns an empty `NamedTuple`.
 """
-initialize(timestepper::AbstractTimeStepper, model, state) = (;)
+initialize(timestepper::AbstractTimeStepper, state) = (;)
+initialize(::Nothing, state) = (;)
 
 """
     $SIGNATURES

--- a/src/timesteppers/forward_euler.jl
+++ b/src/timesteppers/forward_euler.jl
@@ -14,8 +14,6 @@ default_dt(euler::ForwardEuler) = euler.Δt
 
 is_adaptive(euler::ForwardEuler) = false
 
-is_initialized(euler::ForwardEuler) = true
-
 function timestep!(integrator::ModelIntegrator, timestepper::ForwardEuler, Δt)
     # Compute auxiliaries and tendencies
     update_state!(integrator, compute_tendencies = true)

--- a/src/timesteppers/heun.jl
+++ b/src/timesteppers/heun.jl
@@ -63,7 +63,7 @@ function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default
 
     # Predictor: compute tendencies ∂u∂t₀ at the current state u₀
     update_state!(state, model, inputs, compute_tendencies = true)
-    # Snapshot u₀ and ∂u∂t₀
+    # Cache u₀ and ∂u∂t₀
     save_heun_cache!(state)
 
     # Step state forward in place using ∂u∂t₀

--- a/src/timesteppers/heun.jl
+++ b/src/timesteppers/heun.jl
@@ -25,8 +25,8 @@ end
 # Save current prognostic and tendencies into the Heun cache. Recurses into namespaces.
 function save_cache!(ts::Heun, state::StateVariables)
     for name in prognostic_names(state)
-        copyto!(state.cache.prognostic[name], state.prognostic[name])
-        copyto!(state.cache.tendencies[name], state.tendencies[name])
+        copyto!(state.timestepper_cache.prognostic[name], state.prognostic[name])
+        copyto!(state.timestepper_cache.tendencies[name], state.tendencies[name])
     end
     fastiterate(state.namespaces) do ns
         save_cache!(ts, ns)
@@ -37,7 +37,7 @@ end
 # Restore prognostic fields from the cache. Recurses into namespaces.
 function restore_prognostic!(ts::Heun, state::StateVariables)
     for name in prognostic_names(state)
-        copyto!(state.prognostic[name], state.cache.prognostic[name])
+        copyto!(state.prognostic[name], state.timestepper_cache.prognostic[name])
     end
     fastiterate(state.namespaces) do ns
         restore_prognostic!(ts, ns)
@@ -46,10 +46,10 @@ function restore_prognostic!(ts::Heun, state::StateVariables)
 end
 
 # Average current tendencies with the saved predictor tendencies in-place:
-# state.tendencies ← (state.tendencies + cache.tendencies) / 2. Recurses into namespaces.
+# state.tendencies ← (state.tendencies + timestepper_cache.tendencies) / 2. Recurses into namespaces.
 function average_tendencies!(ts::Heun, state::StateVariables)
     for name in prognostic_names(state)
-        state.tendencies[name] .= (state.tendencies[name] .+ state.cache.tendencies[name]) ./ 2
+        state.tendencies[name] .= (state.tendencies[name] .+ state.timestepper_cache.tendencies[name]) ./ 2
     end
     fastiterate(state.namespaces) do ns
         average_tendencies!(ts, ns)
@@ -76,9 +76,9 @@ function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default
     # Recompute tendencies ∂u∂t₁ at the predictor state (u_pred, t + Δt)
     update_state!(state, model, inputs, compute_tendencies = true)
     # Average tendencies in place: state.tendencies ← (∂u∂t₀ + ∂u∂t₁) / 2
-    average_tendencies!(ts, state)
+    average_tendencies!(timestepper, state)
     # Restore the prognostic state to u₀ before the corrector explicit step
-    restore_prognostic!(ts, state)
+    restore_prognostic!(timestepper, state)
 
     # Corrector: u ← u₀ + Δt · averaged tendencies
     explicit_step!(state, grid, timestepper, Δt)

--- a/src/timesteppers/heun.jl
+++ b/src/timesteppers/heun.jl
@@ -23,36 +23,36 @@ function initialize(::Heun, state::AbstractStateVariables)
 end
 
 # Save current prognostic and tendencies into the Heun cache. Recurses into namespaces.
-function save_heun_cache!(state::StateVariables)
+function save_cache!(ts::Heun, state::StateVariables)
     for name in prognostic_names(state)
         copyto!(state.cache.prognostic[name], state.prognostic[name])
         copyto!(state.cache.tendencies[name], state.tendencies[name])
     end
     fastiterate(state.namespaces) do ns
-        save_heun_cache!(ns)
+        save_cache!(ts, ns)
     end
     return nothing
 end
 
 # Restore prognostic fields from the cache. Recurses into namespaces.
-function restore_heun_prognostic!(state::StateVariables)
+function restore_prognostic!(ts::Heun, state::StateVariables)
     for name in prognostic_names(state)
         copyto!(state.prognostic[name], state.cache.prognostic[name])
     end
     fastiterate(state.namespaces) do ns
-        restore_heun_prognostic!(ns)
+        restore_prognostic!(ts, ns)
     end
     return nothing
 end
 
 # Average current tendencies with the saved predictor tendencies in-place:
 # state.tendencies ← (state.tendencies + cache.tendencies) / 2. Recurses into namespaces.
-function average_heun_tendencies!(state::StateVariables)
+function average_tendencies!(ts::Heun, state::StateVariables)
     for name in prognostic_names(state)
         state.tendencies[name] .= (state.tendencies[name] .+ state.cache.tendencies[name]) ./ 2
     end
     fastiterate(state.namespaces) do ns
-        average_heun_tendencies!(ns)
+        average_tendencies!(ts, ns)
     end
     return nothing
 end
@@ -64,7 +64,7 @@ function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default
     # Predictor: compute tendencies ∂u∂t₀ at the current state u₀
     update_state!(state, model, inputs, compute_tendencies = true)
     # Cache u₀ and ∂u∂t₀
-    save_heun_cache!(state)
+    save_cache!(timestepper, state)
 
     # Step state forward in place using ∂u∂t₀
     explicit_step!(state, grid, timestepper, Δt)
@@ -76,9 +76,9 @@ function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default
     # Recompute tendencies ∂u∂t₁ at the predictor state (u_pred, t + Δt)
     update_state!(state, model, inputs, compute_tendencies = true)
     # Average tendencies in place: state.tendencies ← (∂u∂t₀ + ∂u∂t₁) / 2
-    average_heun_tendencies!(state)
+    average_tendencies!(ts, state)
     # Restore the prognostic state to u₀ before the corrector explicit step
-    restore_heun_prognostic!(state)
+    restore_prognostic!(ts, state)
 
     # Corrector: u ← u₀ + Δt · averaged tendencies
     explicit_step!(state, grid, timestepper, Δt)

--- a/src/timesteppers/heun.jl
+++ b/src/timesteppers/heun.jl
@@ -23,36 +23,36 @@ function initialize(::Heun, state::AbstractStateVariables)
 end
 
 # Save current prognostic and tendencies into the Heun cache. Recurses into namespaces.
-function save_cache!(ts::Heun, state::StateVariables)
+function save_cache!(state::StateVariables, ts::Heun)
     for name in prognostic_names(state)
         copyto!(state.timestepper_cache.prognostic[name], state.prognostic[name])
         copyto!(state.timestepper_cache.tendencies[name], state.tendencies[name])
     end
     fastiterate(state.namespaces) do ns
-        save_cache!(ts, ns)
+        save_cache!(ns, ts)
     end
     return nothing
 end
 
 # Restore prognostic fields from the cache. Recurses into namespaces.
-function restore_prognostic!(ts::Heun, state::StateVariables)
+function restore_prognostic!(state::StateVariables, ts::Heun)
     for name in prognostic_names(state)
         copyto!(state.prognostic[name], state.timestepper_cache.prognostic[name])
     end
     fastiterate(state.namespaces) do ns
-        restore_prognostic!(ts, ns)
+        restore_prognostic!(ns, ts)
     end
     return nothing
 end
 
 # Average current tendencies with the saved predictor tendencies in-place:
 # state.tendencies ← (state.tendencies + timestepper_cache.tendencies) / 2. Recurses into namespaces.
-function average_tendencies!(ts::Heun, state::StateVariables)
+function average_tendencies!(state::StateVariables, ts::Heun)
     for name in prognostic_names(state)
         state.tendencies[name] .= (state.tendencies[name] .+ state.timestepper_cache.tendencies[name]) ./ 2
     end
     fastiterate(state.namespaces) do ns
-        average_tendencies!(ts, ns)
+        average_tendencies!(ns, ts)
     end
     return nothing
 end
@@ -64,7 +64,7 @@ function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default
     # Predictor: compute tendencies ∂u∂t₀ at the current state u₀
     update_state!(state, model, inputs, compute_tendencies = true)
     # Cache u₀ and ∂u∂t₀
-    save_cache!(timestepper, state)
+    save_cache!(state, timestepper)
 
     # Step state forward in place using ∂u∂t₀
     explicit_step!(state, grid, timestepper, Δt)
@@ -76,9 +76,9 @@ function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default
     # Recompute tendencies ∂u∂t₁ at the predictor state (u_pred, t + Δt)
     update_state!(state, model, inputs, compute_tendencies = true)
     # Average tendencies in place: state.tendencies ← (∂u∂t₀ + ∂u∂t₁) / 2
-    average_tendencies!(timestepper, state)
+    average_tendencies!(state, timestepper)
     # Restore the prognostic state to u₀ before the corrector explicit step
-    restore_prognostic!(timestepper, state)
+    restore_prognostic!(state, timestepper)
 
     # Corrector: u ← u₀ + Δt · averaged tendencies
     explicit_step!(state, grid, timestepper, Δt)

--- a/src/timesteppers/heun.jl
+++ b/src/timesteppers/heun.jl
@@ -3,63 +3,84 @@
 
 Simple forward 2nd order Heun / improved Euler time stepping scheme.
 """
-@kwdef struct Heun{NF, Stage} <: AbstractTimeStepper{NF}
+@kwdef struct Heun{NF} <: AbstractTimeStepper{NF}
     "Initial timestep size in seconds"
     Δt::NF = 300.0
-
-    "Stage (Cache) for intermediate results"
-    stage::Stage = nothing
 end
 
-Heun(::Type{NF}; kwargs...) where {NF} = Heun{NF, Nothing}(; kwargs...)
+Heun(::Type{NF}; kwargs...) where {NF} = Heun{NF}(; kwargs...)
 
 default_dt(heun::Heun) = heun.Δt
 
 is_adaptive(heun::Heun) = false
 
-is_initialized(heun::Heun) = !isnothing(heun.stage)
-
-function initialize(timestepper::Heun{NF}, ::AbstractModel{NF2}, state) where {NF, NF2}
-    @assert NF == NF2 "Time stepper was initialized with eltype(Δt)=$(NF) but model has eltype=$(NF2)"
-    return setproperties(timestepper, stage = deepcopy(state))
+# Allocate cache for the prognostic state `u₀` and the predictor tendencies `∂u∂t₀`.
+# Heun steps in-place on `state`, so only these two NamedTuples of `Field`s are needed.
+function initialize(::Heun, state::AbstractStateVariables)
+    prognostic = map(deepcopy, state.prognostic)
+    tendencies = map(deepcopy, state.tendencies)
+    return (; prognostic, tendencies)
 end
 
-function average_tendencies!(
-        state::StateVariables{NF, prognames},
-        stage::StateVariables{NF, prognames}
-    ) where {NF, prognames}
-    for name in prognames
-        state.tendencies[name] .= (state.tendencies[name] + stage.tendencies[name]) / 2
+# Save current prognostic and tendencies into the Heun cache. Recurses into namespaces.
+function save_heun_cache!(state::StateVariables)
+    for name in prognostic_names(state)
+        copyto!(state.cache.prognostic[name], state.prognostic[name])
+        copyto!(state.cache.tendencies[name], state.tendencies[name])
     end
-    return
+    fastiterate(state.namespaces) do ns
+        save_heun_cache!(ns)
+    end
+    return nothing
+end
+
+# Restore prognostic fields from the cache. Recurses into namespaces.
+function restore_heun_prognostic!(state::StateVariables)
+    for name in prognostic_names(state)
+        copyto!(state.prognostic[name], state.cache.prognostic[name])
+    end
+    fastiterate(state.namespaces) do ns
+        restore_heun_prognostic!(ns)
+    end
+    return nothing
+end
+
+# Average current tendencies with the saved predictor tendencies in-place:
+# state.tendencies ← (state.tendencies + cache.tendencies) / 2. Recurses into namespaces.
+function average_heun_tendencies!(state::StateVariables)
+    for name in prognostic_names(state)
+        state.tendencies[name] .= (state.tendencies[name] .+ state.cache.tendencies[name]) ./ 2
+    end
+    fastiterate(state.namespaces) do ns
+        average_heun_tendencies!(ns)
+    end
+    return nothing
 end
 
 function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default_dt(timestepper))
-    @assert is_initialized(timestepper)
-
     (; model, state, inputs) = integrator
     grid = get_grid(model)
 
-    # Update current state
+    # Predictor: compute tendencies ∂u∂t₀ at the current state u₀
     update_state!(state, model, inputs, compute_tendencies = true)
+    # Snapshot u₀ and ∂u∂t₀
+    save_heun_cache!(state)
 
-    # Copy current state to stage
-    stage = timestepper.stage
-    copyto!(stage, state)
-
-    # Compute stage
-    explicit_step!(stage, grid, timestepper, Δt)
+    # Step state forward in place using ∂u∂t₀
+    explicit_step!(state, grid, timestepper, Δt)
     # Call timestep! on model
-    timestep!(stage, model, timestepper, Δt)
+    timestep!(state, model, timestepper, Δt)
     # Apply closure relations
-    closure!(stage, model)
-    # Update clock
-    tick!(stage.clock, Δt)
-    # Recompute tendencies after timestep
-    update_state!(stage, model, inputs, compute_tendencies = true)
+    closure!(state, model)
+ 
+    # Recompute tendencies ∂u∂t₁ at the predictor state (u_pred, t + Δt)
+    update_state!(state, model, inputs, compute_tendencies = true)
+    # Average tendencies in place: state.tendencies ← (∂u∂t₀ + ∂u∂t₁) / 2
+    average_heun_tendencies!(state)
+    # Restore the prognostic state to u₀ before the corrector explicit step
+    restore_heun_prognostic!(state)
 
-    # Final improved Euler step call that steps `state` forward but averages `state.tendencies`
-    average_tendencies!(state, stage)
+    # Corrector: u ← u₀ + Δt · averaged tendencies
     explicit_step!(state, grid, timestepper, Δt)
     # Call timestep! on model
     timestep!(state, model, timestepper, Δt)

--- a/src/timesteppers/heun.jl
+++ b/src/timesteppers/heun.jl
@@ -72,7 +72,7 @@ function timestep!(integrator::ModelIntegrator, timestepper::Heun, Δt = default
     timestep!(state, model, timestepper, Δt)
     # Apply closure relations
     closure!(state, model)
- 
+
     # Recompute tendencies ∂u∂t₁ at the predictor state (u_pred, t + Δt)
     update_state!(state, model, inputs, compute_tendencies = true)
     # Average tendencies in place: state.tendencies ← (∂u∂t₀ + ∂u∂t₁) / 2

--- a/src/timesteppers/model_integrator.jl
+++ b/src/timesteppers/model_integrator.jl
@@ -153,7 +153,7 @@ function initialize(
     ) where {NF}
     inputs = InputSources(inputs...)
     input_vars = variables(inputs)
-    state = initialize(model; clock, boundary_conditions, fields, input_variables = input_vars)
+    state = initialize(model; clock, timestepper, boundary_conditions, fields, input_variables = input_vars)
     initialized_timestepper = initialize(timestepper, model, state)
     integrator = ModelIntegrator(clock, model, inputs, state, initializers, initialized_timestepper)
     initialize!(integrator)

--- a/src/timesteppers/model_integrator.jl
+++ b/src/timesteppers/model_integrator.jl
@@ -154,8 +154,7 @@ function initialize(
     inputs = InputSources(inputs...)
     input_vars = variables(inputs)
     state = initialize(model; clock, timestepper, boundary_conditions, fields, input_variables = input_vars)
-    initialized_timestepper = initialize(timestepper, model, state)
-    integrator = ModelIntegrator(clock, model, inputs, state, initializers, initialized_timestepper)
+    integrator = ModelIntegrator(clock, model, inputs, state, initializers, timestepper)
     initialize!(integrator)
     return integrator
 end


### PR DESCRIPTION
So far the timestepper is still is in the `ModelIntegrator`. If we move it to the model itself, should both `LandModel` and `SoilModel`/`VegetationModel` have it? In this case both should probably by default just point to the same timestepper, but also allow for different ones. What do you think @bgroenks96 

While doing this here, I also revised the Heun solver to not just deep copy the whole `StateVariables` anymore. Now it is a bit smarter about this. 

Next step still is to put the timestepper in the models. 