### PR TITLE
Test namespaced integration

### DIFF
--- a/src/state_variables.jl
+++ b/src/state_variables.jl
@@ -382,7 +382,7 @@ function initialize(
     namespaces = map(vars.namespaces) do ns
         ns_bcs = get(boundary_conditions, varname(ns), (;))
         ns_fields = get(fields, varname(ns), (;))
-        initialize(ns.vars, grid; clock, boundary_conditions = ns_bcs, fields = ns_fields)
+        initialize(ns.vars, grid; clock, timestepper, boundary_conditions = ns_bcs, fields = ns_fields)
     end
     # get closure variable names
     closurenames = map(varname, closure_variables(values(vars.prognostic)))

--- a/test/timestepping/heun.jl
+++ b/test/timestepping/heun.jl
@@ -65,3 +65,78 @@ end
 
     @test integrator.state.u[2] >= 0.0
 end
+
+# mock a model with the same exponential dynamics as `ExpModel`, but with the prognostic
+# variable (and its auxiliary offset and an input) living inside a namespace `:inner`.
+# This exercises time stepping of prognostic and input variables defined in namespaces and 
+# also tests that actually the correct timestepper is used in the namespace as well. 
+@kwdef struct NamespacedExpModel{NF, Grid <: Terrarium.AbstractLandGrid{NF}, I} <: Terrarium.AbstractModel{NF, Grid}
+    grid::Grid
+    initializer::I = DefaultInitializer(eltype(grid))
+end
+
+Terrarium.variables(::NamespacedExpModel) = (
+    Terrarium.prognostic(:u, Terrarium.XY()),
+    Terrarium.auxiliary(:v, Terrarium.XY()),
+    Terrarium.namespace(:inner, (
+        Terrarium.prognostic(:u, Terrarium.XY()),
+        Terrarium.auxiliary(:v, Terrarium.XY()),
+        Terrarium.input(:c, Terrarium.XY()),
+    )),
+)
+
+# constant offset at the root (v = 0.1); inside the namespace the offset is read from the
+# namespaced input `c`, so that we also exercise input variables defined in a namespace.
+function Terrarium.compute_auxiliary!(state, model::NamespacedExpModel)
+    state.auxiliary.v .= 0.1
+    state.namespaces.inner.auxiliary.v .= state.namespaces.inner.inputs.c
+    return nothing
+end
+
+# du/dt = u + v at both the root and inside the namespace
+function Terrarium.compute_tendencies!(state, model::NamespacedExpModel)
+    set!(state.tendencies.u, state.prognostic.u + state.auxiliary.v)
+    set!(state.namespaces.inner.tendencies.u, state.namespaces.inner.prognostic.u + state.namespaces.inner.auxiliary.v)
+    return nothing
+end
+
+@testset "NamespacedExpModel: time stepping prognostic/input in a namespace" begin
+    grid = ColumnGrid(CPU(), Float64, UniformSpacing(N = 1))
+    model = NamespacedExpModel(grid)
+
+    # root initializers only; the namespaced prognostic `u` starts at its default (zero) and
+    # the namespaced input `c` (which has no input source) is set explicitly below.
+    initializers = (u = 0.0, v = 0.1)
+    integrator_heun = initialize(model, Heun(); initializers)
+    integrator_euler = initialize(model, ForwardEuler(); initializers)
+
+    # the model must define namespaced variables (prognostic, auxiliary, and input)
+    @test haskey(integrator_euler.state.namespaces, :inner)
+    @test :u in keys(integrator_euler.state.namespaces.inner.prognostic)
+    @test :c in keys(integrator_euler.state.namespaces.inner.inputs)
+
+    # set the namespaced input; the namespaced offset `v` reads from it, giving the same
+    # dynamics (du/dt = u + 0.1) inside the namespace as the root variable.
+    set!(integrator_heun.state.namespaces.inner.inputs.c, 0.1)
+    set!(integrator_euler.state.namespaces.inner.inputs.c, 0.1)
+
+    timestep!(integrator_heun)
+    timestep!(integrator_euler)
+
+    u_inner_euler = integrator_euler.state.namespaces.inner.prognostic.u
+    u_inner_heun = integrator_heun.state.namespaces.inner.prognostic.u
+
+    # the namespaced prognostic actually integrated, and Heun is more accurate than Euler
+    @test u_inner_heun[2] > u_inner_euler[2]
+
+    # the namespaced prognostic integrates identically to the root variable (same dynamics),
+    # confirming both the root and the namespace are stepped consistently
+    @test integrator_euler.state.u[2] == u_inner_euler[2]
+    @test integrator_heun.state.u[2] == u_inner_heun[2]
+
+    # exact integrated values for the namespaced prognostic
+    dt_euler = default_dt(integrator_euler.timestepper)
+    @test u_inner_euler[2] == 0.1 * dt_euler
+    dt_heun = default_dt(integrator_heun.timestepper)
+    @test u_inner_heun[2] == (0.1 * dt_heun + (0.1 * dt_heun + 0.1) * dt_heun) / 2
+end

--- a/test/timestepping/heun.jl
+++ b/test/timestepping/heun.jl
@@ -68,8 +68,8 @@ end
 
 # mock a model with the same exponential dynamics as `ExpModel`, but with the prognostic
 # variable (and its auxiliary offset and an input) living inside a namespace `:inner`.
-# This exercises time stepping of prognostic and input variables defined in namespaces and 
-# also tests that actually the correct timestepper is used in the namespace as well. 
+# This exercises time stepping of prognostic and input variables defined in namespaces and
+# also tests that actually the correct timestepper is used in the namespace as well.
 @kwdef struct NamespacedExpModel{NF, Grid <: Terrarium.AbstractLandGrid{NF}, I} <: Terrarium.AbstractModel{NF, Grid}
     grid::Grid
     initializer::I = DefaultInitializer(eltype(grid))
@@ -78,11 +78,13 @@ end
 Terrarium.variables(::NamespacedExpModel) = (
     Terrarium.prognostic(:u, Terrarium.XY()),
     Terrarium.auxiliary(:v, Terrarium.XY()),
-    Terrarium.namespace(:inner, (
-        Terrarium.prognostic(:u, Terrarium.XY()),
-        Terrarium.auxiliary(:v, Terrarium.XY()),
-        Terrarium.input(:c, Terrarium.XY()),
-    )),
+    Terrarium.namespace(
+        :inner, (
+            Terrarium.prognostic(:u, Terrarium.XY()),
+            Terrarium.auxiliary(:v, Terrarium.XY()),
+            Terrarium.input(:c, Terrarium.XY()),
+        )
+    ),
 )
 
 # constant offset at the root (v = 0.1); inside the namespace the offset is read from the


### PR DESCRIPTION
Related to #125, but stand-alone, this adds a test that integrating a model with variables in namespaces actually works and also fixes a minor issue that prevented it from working correctly before 